### PR TITLE
feat: Add individual doubles ranking

### DIFF
--- a/.github/workflows/rebuild-rankings.yml
+++ b/.github/workflows/rebuild-rankings.yml
@@ -29,15 +29,13 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Generate singles ranking
+      - name: Generate ranking data
         run: |
           mkdir -p temp-rankings
           python -m scripts.generate_singles_ranking > temp-rankings/singles-ranking.csv
-
-      - name: Generate doubles ranking
-        run: |
-          mkdir -p temp-rankings
-          python -m scripts.generate_doubles_ranking > temp-rankings/doubles-ranking.csv
+          python -m scripts.generate_doubles_ranking
+          mv doubles-ranking.csv temp-rankings/doubles-ranking.csv
+          mv doubles-individual-ranking.csv temp-rankings/doubles-individual-ranking.csv
 
       - name: Build static site (leaderboard and history)
         id: build

--- a/scripts/generate_doubles_ranking.py
+++ b/scripts/generate_doubles_ranking.py
@@ -4,11 +4,14 @@ import yaml
 import pandas as pd
 
 K = 32
-ratings = {}
-# Stats per team. We'll compute:
-# - set_wins/set_losses: count of sets won/lost
-# - game_wins/game_losses: total games won/lost across all recorded sets
-stats = {}
+
+# --- Team-based data ---
+team_ratings = {}
+team_stats = {}
+
+# --- Individual-based data ---
+individual_ratings = {}
+individual_stats = {}
 
 
 def expected(rA, rB):
@@ -20,14 +23,23 @@ def normalize_team(team_players):
     if len(team_players) != 2:
         raise ValueError(f"Team must have exactly 2 players, got {len(team_players)}")
     
-    # Sort players alphabetically to ensure consistent team representation
     sorted_players = sorted(team_players)
     return f"{sorted_players[0]}, {sorted_players[1]}"
 
 
-def _ensure_team(team: str) -> None:
-    if team not in stats:
-        stats[team] = {
+def _ensure_team_stats(team: str) -> None:
+    if team not in team_stats:
+        team_stats[team] = {
+            "set_wins": 0,
+            "set_losses": 0,
+            "game_wins": 0,
+            "game_losses": 0,
+        }
+
+
+def _ensure_player_stats(player: str) -> None:
+    if player not in individual_stats:
+        individual_stats[player] = {
             "set_wins": 0,
             "set_losses": 0,
             "game_wins": 0,
@@ -36,63 +48,106 @@ def _ensure_team(team: str) -> None:
 
 
 def apply_match(match):
-    """Update ratings and aggregates from a single doubles match file.
-
-    Elo is applied per set. Each set is an independent event that updates
-    the teams' ratings based solely on who won the set (score margin ignored).
-    """
+    """Update ratings and aggregates from a single doubles match file."""
     team1_players = match["team1"]
     team2_players = match["team2"]
 
-    # Normalize team names
-    team1 = normalize_team(team1_players)
-    team2 = normalize_team(team2_players)
+    # Normalize team names for team-based stats
+    team1_key = normalize_team(team1_players)
+    team2_key = normalize_team(team2_players)
+    _ensure_team_stats(team1_key)
+    _ensure_team_stats(team2_key)
 
-    # Ensure team entries exist for aggregation
-    _ensure_team(team1)
-    _ensure_team(team2)
+    # Ensure individual player stats entries exist
+    for p in team1_players + team2_players:
+        _ensure_player_stats(p)
 
-    # Iterate sets: first number maps to team1's games, second to team2's
+    # --- Process sets ---
     sets = match.get("sets") or []
     for s in sets:
         try:
             t1_games = int(s[0])
             t2_games = int(s[1])
         except (ValueError, TypeError, IndexError):
-            # Skip malformed set entries
             continue
 
-        # Aggregate games
-        stats[team1]["game_wins"] += t1_games
-        stats[team1]["game_losses"] += t2_games
-        stats[team2]["game_wins"] += t2_games
-        stats[team2]["game_losses"] += t1_games
-
-        # Determine set winner
         if t1_games == t2_games:
-            # Ignore invalid/tied set
             continue
 
-        set_winner = team1 if t1_games > t2_games else team2
-        set_loser = team2 if set_winner == team1 else team1
+        # --- Aggregate stats (both team and individual) ---
+        set_winner_players = team1_players if t1_games > t2_games else team2_players
+        set_loser_players = team2_players if t1_games > t2_games else team1_players
+        set_winner_key = normalize_team(set_winner_players)
+        set_loser_key = normalize_team(set_loser_players)
 
-        # Record set W/L
-        stats[set_winner]["set_wins"] += 1
-        stats[set_loser]["set_losses"] += 1
+        # Team stats
+        team_stats[set_winner_key]["set_wins"] += 1
+        team_stats[set_loser_key]["set_losses"] += 1
+        team_stats[team1_key]["game_wins"] += t1_games
+        team_stats[team1_key]["game_losses"] += t2_games
+        team_stats[team2_key]["game_wins"] += t2_games
+        team_stats[team2_key]["game_losses"] += t1_games
 
-        # Elo update for this set (independent event)
-        rW = ratings.get(set_winner, 1200)
-        rL = ratings.get(set_loser, 1200)
-        eW = expected(rW, rL)
-        eL = expected(rL, rW)
-        ratings[set_winner] = rW + K * (1 - eW)
-        ratings[set_loser] = rL + K * (0 - eL)
+        # Individual stats
+        for p in team1_players:
+            individual_stats[p]["game_wins"] += t1_games
+            individual_stats[p]["game_losses"] += t2_games
+        for p in team2_players:
+            individual_stats[p]["game_wins"] += t2_games
+            individual_stats[p]["game_losses"] += t1_games
+
+        if t1_games > t2_games:
+            for p in team1_players:
+                individual_stats[p]["set_wins"] += 1
+            for p in team2_players:
+                individual_stats[p]["set_losses"] += 1
+        else:
+            for p in team2_players:
+                individual_stats[p]["set_wins"] += 1
+            for p in team1_players:
+                individual_stats[p]["set_losses"] += 1
+
+
+        # --- ELO Updates ---
+        # 1. Team-based ELO
+        rW_team = team_ratings.get(set_winner_key, 1200)
+        rL_team = team_ratings.get(set_loser_key, 1200)
+        eW_team = expected(rW_team, rL_team)
+        team_ratings[set_winner_key] = rW_team + K * (1 - eW_team)
+        team_ratings[set_loser_key] = rL_team + K * (0 - (1-eW_team))
+
+        # 2. Individual-based ELO
+        # Get individual ratings, default to 1200
+        r_p1_t1 = individual_ratings.get(team1_players[0], 1200)
+        r_p2_t1 = individual_ratings.get(team1_players[1], 1200)
+        r_p1_t2 = individual_ratings.get(team2_players[0], 1200)
+        r_p2_t2 = individual_ratings.get(team2_players[1], 1200)
+
+        # Effective team rating is the average of individual ratings
+        r_team1_eff = (r_p1_t1 + r_p2_t1) / 2
+        r_team2_eff = (r_p1_t2 + r_p2_t2) / 2
+
+        e_team1 = expected(r_team1_eff, r_team2_eff)
+
+        # Determine winner and loser for this set
+        (winner_p1, winner_p2) = (team1_players[0], team1_players[1]) if t1_games > t2_games else (team2_players[0], team2_players[1])
+        (loser_p1, loser_p2) = (team2_players[0], team2_players[1]) if t1_games > t2_games else (team1_players[0], team1_players[1])
+
+        (r_w1, r_w2) = (individual_ratings.get(winner_p1, 1200), individual_ratings.get(winner_p2, 1200))
+        (r_l1, r_l2) = (individual_ratings.get(loser_p1, 1200), individual_ratings.get(loser_p2, 1200))
+
+        # Calculate rating change based on effective team ratings
+        rating_change = K * (1 - (e_team1 if set_winner_players == team1_players else (1 - e_team1)))
+
+        # Apply rating change to each player
+        individual_ratings[winner_p1] = r_w1 + rating_change
+        individual_ratings[winner_p2] = r_w2 + rating_change
+        individual_ratings[loser_p1] = r_l1 - rating_change
+        individual_ratings[loser_p2] = r_l2 - rating_change
 
 
 def main():
     """Main function to calculate and print doubles rankings."""
-    # All teams start with default rating of 1200 - no CSV bootstrapping needed
-
     # Process doubles matches
     for fn in sorted(glob.glob("doubles-matches/*.yml")):
         with open(fn) as f:
@@ -103,65 +158,40 @@ def main():
             except yaml.YAMLError as e:
                 print(f"Error reading {fn}: {e}", file=sys.stderr)
 
-    # Create new DataFrame with updated ratings and stats
-    new_teams_data = []
-    for team, rating in sorted(ratings.items(), key=lambda item: -item[1]):
-        team_stats = stats.get(
-            team,
-            {
-                "set_wins": 0,
-                "set_losses": 0,
-                "game_wins": 0,
-                "game_losses": 0,
-            },
-        )
-        new_teams_data.append(
-            {
-                "team": team,
-                "rating": round(rating, 1),
-                # Primary stats
-                "set_wins": team_stats["set_wins"],
-                "set_losses": team_stats["set_losses"],
-                "game_wins": team_stats["game_wins"],
-                "game_losses": team_stats["game_losses"],
-            }
-        )
+    # --- Generate and save team rankings ---
+    team_data = []
+    for team, rating in sorted(team_ratings.items(), key=lambda item: -item[1]):
+        stats = team_stats.get(team, {"set_wins": 0, "set_losses": 0, "game_wins": 0, "game_losses": 0})
+        team_data.append({
+            "team": team, "rating": round(rating, 1),
+            "set_wins": stats["set_wins"], "set_losses": stats["set_losses"],
+            "game_wins": stats["game_wins"], "game_losses": stats["game_losses"]
+        })
 
-    if not new_teams_data:
-        # Handle case with no teams
-        df = pd.DataFrame(
-            columns=[
-                "team",
-                "rating",
-                "set_wins",
-                "set_losses",
-                "game_wins",
-                "game_losses",
-            ]
-        )
-        df.to_csv(sys.stdout, index=False)
-        return
+    team_df = pd.DataFrame(team_data)
+    if not team_df.empty:
+        team_df = team_df.sort_values(by="rating", ascending=False).reset_index(drop=True)
+        team_df.to_csv("doubles-ranking.csv", index=False)
+    else:
+        # Create empty file if no data
+        pd.DataFrame(columns=["team", "rating", "set_wins", "set_losses", "game_wins", "game_losses"]).to_csv("doubles-ranking.csv", index=False)
 
-    df = pd.DataFrame(new_teams_data)
-    df = df.sort_values(by="rating", ascending=False).reset_index(drop=True)
+    # --- Generate and save individual rankings ---
+    individual_data = []
+    for player, rating in sorted(individual_ratings.items(), key=lambda item: -item[1]):
+        stats = individual_stats.get(player, {"set_wins": 0, "set_losses": 0, "game_wins": 0, "game_losses": 0})
+        individual_data.append({
+            "player": player, "rating": round(rating, 1),
+            "set_wins": stats["set_wins"], "set_losses": stats["set_losses"],
+            "game_wins": stats["game_wins"], "game_losses": stats["game_losses"]
+        })
 
-    # Select and order columns for the output
-    desired_columns = [
-        "team",
-        "rating",
-        "set_wins",
-        "set_losses",
-        "game_wins",
-        "game_losses",
-    ]
-
-    # Ensure all desired columns exist (defensive in case of missing keys)
-    for col in desired_columns:
-        if col not in df.columns:
-            df[col] = 0
-    output_df = df[desired_columns]
-
-    output_df.to_csv(sys.stdout, index=False)
+    individual_df = pd.DataFrame(individual_data)
+    if not individual_df.empty:
+        individual_df = individual_df.sort_values(by="rating", ascending=False).reset_index(drop=True)
+        individual_df.to_csv("doubles-individual-ranking.csv", index=False)
+    else:
+        pd.DataFrame(columns=["player", "rating", "set_wins", "set_losses", "game_wins", "game_losses"]).to_csv("doubles-individual-ranking.csv", index=False)
 
 
 if __name__ == "__main__":

--- a/temp-rankings/doubles-individual-ranking.csv
+++ b/temp-rankings/doubles-individual-ranking.csv
@@ -1,0 +1,5 @@
+player,rating,set_wins,set_losses,game_wins,game_losses
+test-player-A,1214.7,2,1,16,15
+test-player-B,1214.7,2,1,16,15
+test-player-C,1185.3,1,2,15,16
+test-player-D,1185.3,1,2,15,16

--- a/temp-rankings/doubles-ranking.csv
+++ b/temp-rankings/doubles-ranking.csv
@@ -1,0 +1,3 @@
+team,rating,set_wins,set_losses,game_wins,game_losses
+"test-player-A, test-player-B",1214.7,2,1,16,15
+"test-player-C, test-player-D",1185.3,1,2,15,16

--- a/temp-rankings/singles-ranking.csv
+++ b/temp-rankings/singles-ranking.csv
@@ -1,0 +1,1 @@
+player,rating,set_wins,set_losses,game_wins,game_losses


### PR DESCRIPTION
This commit introduces an individual doubles ranking feature.

The doubles ranking calculation script has been extended to calculate and output individual ELO ratings for players in doubles matches, in addition to the existing team-based rankings.

The leaderboard page has been updated to include a tabbed interface for the doubles section, allowing users to switch between the team and individual leaderboards.