### PR TITLE
feat: Add new features and refactor ELO logic

### DIFF
--- a/scripts/build_pages.py
+++ b/scripts/build_pages.py
@@ -28,6 +28,36 @@ def load_ranking_data(file_path: str, columns: list[str]):
     return df.sort_values(by="rating", ascending=False).reset_index(drop=True)
 
 
+def generate_marquee_content():
+    """Generate HTML for a marquee banner of recent Elo changes."""
+    try:
+        elo_changes_df = pd.read_csv("temp-rankings/elo_changes.csv")
+        # Get the last 20 ELO changes
+        recent_changes = elo_changes_df.tail(20)
+
+        if recent_changes.empty:
+            return "No recent ELO changes."
+
+        parts = []
+        for _, row in recent_changes.iterrows():
+            player = row["player"]
+            change = row["change"]
+
+            if change > 0:
+                arrow = f'<span style="color: green;">▲</span>'
+                sign = "+"
+            else:
+                arrow = f'<span style="color: red;">▼</span>'
+                sign = ""
+
+            parts.append(f'{player} {arrow} {sign}{change:.1f}')
+
+        return " • ".join(parts)
+
+    except FileNotFoundError:
+        return "🎾 No ball boys were harmed in the making of these statistics • Serving up fresh rankings daily! • Love means nothing in tennis, but these scores mean everything! • Deuce you believe these rankings? • Game, Set, Match... and GitHub Issues! 🎾"
+
+
 def generate_singles_table(df: pd.DataFrame):
     """Generate HTML table for singles leaderboard"""
     df.index += 1
@@ -192,17 +222,17 @@ def build_site():
         <h2>👥 Doubles Leaderboard</h2>
         <ul class="nav nav-tabs" id="doublesTab" role="tablist">
             <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="teams-tab" data-bs-toggle="tab" data-bs-target="#teams" type="button" role="tab" aria-controls="teams" aria-selected="true">Teams</button>
+                <button class="nav-link" id="teams-tab" data-bs-toggle="tab" data-bs-target="#teams" type="button" role="tab" aria-controls="teams" aria-selected="false">Teams</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="individuals-tab" data-bs-toggle="tab" data-bs-target="#individuals" type="button" role="tab" aria-controls="individuals" aria-selected="false">Individuals</button>
+                <button class="nav-link active" id="individuals-tab" data-bs-toggle="tab" data-bs-target="#individuals" type="button" role="tab" aria-controls="individuals" aria-selected="true">Individuals</button>
             </li>
         </ul>
         <div class="tab-content" id="doublesTabContent">
-            <div class="tab-pane fade show active" id="teams" role="tabpanel" aria-labelledby="teams-tab">
+            <div class="tab-pane fade" id="teams" role="tabpanel" aria-labelledby="teams-tab">
                 {doubles_team_table}
             </div>
-            <div class="tab-pane fade" id="individuals" role="tabpanel" aria-labelledby="individuals-tab">
+            <div class="tab-pane fade show active" id="individuals" role="tabpanel" aria-labelledby="individuals-tab">
                 {doubles_individual_table}
             </div>
         </div>
@@ -276,7 +306,7 @@ def build_site():
             <h1>🏆 Tennis Leaderboards</h1>
 
             <marquee behavior="scroll" direction="left" bgcolor="#f8f9fa" style="padding: 10px; margin-bottom: 2rem; border: 1px solid #dee2e6; border-radius: 0.375rem; font-weight: 500;">
-                🎾 No ball boys were harmed in the making of these statistics • Serving up fresh rankings daily! • Love means nothing in tennis, but these scores mean everything! • Deuce you believe these rankings? • Game, Set, Match... and GitHub Issues! 🎾
+                {generate_marquee_content()}
             </marquee>
 
             <div class="leaderboards-container">

--- a/scripts/elo_utils.py
+++ b/scripts/elo_utils.py
@@ -1,0 +1,76 @@
+"""
+This module provides shared ELO rating calculation functions.
+"""
+
+K = 32
+
+def expected(rA, rB):
+    """
+    Calculate the expected score of player A in a match against player B.
+    """
+    return 1 / (1 + 10 ** ((rB - rA) / 400))
+
+def update_elo_ratings(ratings, winner, loser):
+    """
+    Updates the ELO ratings for a winner and loser.
+
+    Args:
+        ratings (dict): A dictionary of player ratings.
+        winner (str): The name of the winner.
+        loser (str): The name of the loser.
+
+    Returns:
+        tuple: A tuple containing the new rating for the winner and loser.
+    """
+    rW = ratings.get(winner, 1200)
+    rL = ratings.get(loser, 1200)
+    eW = expected(rW, rL)
+    eL = expected(rL, rW)
+
+    new_rW = rW + K * (1 - eW)
+    new_rL = rL + K * (0 - eL)
+
+    return new_rW, new_rL
+
+def normalize_team(team_players):
+    """Normalize team representation so PlayerA,PlayerB == PlayerB,PlayerA"""
+    if len(team_players) != 2:
+        raise ValueError(f"Team must have exactly 2 players, got {len(team_players)}")
+
+    sorted_players = sorted(team_players)
+    return f"{sorted_players[0]}, {sorted_players[1]}"
+
+def update_doubles_elo_ratings(team_ratings, individual_ratings, winner_team, loser_team):
+    """
+    Updates the ELO ratings for a doubles match.
+    """
+    # 1. Team-based ELO
+    winner_team_key = f"{sorted(winner_team)[0]}, {sorted(winner_team)[1]}"
+    loser_team_key = f"{sorted(loser_team)[0]}, {sorted(loser_team)[1]}"
+
+    rW_team = team_ratings.get(winner_team_key, 1200)
+    rL_team = team_ratings.get(loser_team_key, 1200)
+    eW_team = expected(rW_team, rL_team)
+
+    new_rW_team = rW_team + K * (1 - eW_team)
+    new_rL_team = rL_team + K * (0 - (1-eW_team))
+
+    # 2. Individual-based ELO
+    r_w1 = individual_ratings.get(winner_team[0], 1200)
+    r_w2 = individual_ratings.get(winner_team[1], 1200)
+    r_l1 = individual_ratings.get(loser_team[0], 1200)
+    r_l2 = individual_ratings.get(loser_team[1], 1200)
+
+    r_winner_eff = (r_w1 + r_w2) / 2
+    r_loser_eff = (r_l1 + r_l2) / 2
+
+    e_winner = expected(r_winner_eff, r_loser_eff)
+
+    rating_change = K * (1 - e_winner)
+
+    new_r_w1 = r_w1 + rating_change
+    new_r_w2 = r_w2 + rating_change
+    new_r_l1 = r_l1 - rating_change
+    new_r_l2 = r_l2 - rating_change
+
+    return new_rW_team, new_rL_team, new_r_w1, new_r_w2, new_r_l1, new_r_l2


### PR DESCRIPTION
This commit introduces several new features and improvements:

- The doubles ranking now defaults to the individual tab.
- The marquee element at the top now shows recent ELO changes for singles players.
- The match history now shows ELO gain/loss for each match.
- The ELO calculation logic has been refactored into a separate utility file to avoid code duplication.
- A bug in the doubles ELO calculation in the match history has been fixed.